### PR TITLE
Fixing some dimensions when assigning values to arrays 

### DIFF
--- a/src/pamm.f90
+++ b/src/pamm.f90
@@ -469,8 +469,8 @@
             IF(counter.EQ.nbuff) THEN
                DEALLOCATE(wtmp,vtmp)
                ALLOCATE(wtmp(nsamples+counter), vtmp(D,nsamples+counter))
-               wtmp(1:nsamples) = wj
-               vtmp(:,1:nsamples) = xj
+               if(nsamples>0) wtmp(1:nsamples) = wj
+               if (nsamples>0) vtmp(:,1:nsamples) = xj
                wtmp(nsamples+1:nsamples+counter) = wbuff
                vtmp(:,nsamples+1:nsamples+counter) = vbuff
 


### PR DESCRIPTION
This only broke when compiling with specific "check" flags:

In the first pass, arrays were trying to receive numbers from position
 1 to position 0 in pamm.f90. I have tried to catch this instance -- please check
 that this does not create problems anywhere else, and that the fix I did is okay.
